### PR TITLE
Add PIDUtils and related classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java"
-    id "edu.wpi.first.GradleRIO" version "2024.1.1"
+    id "edu.wpi.first.GradleRIO" version "2024.2.1"
     id 'com.diffplug.spotless' version '6.20.0'
 }
 

--- a/src/main/java/frc/utils/pid/PIDConfig.java
+++ b/src/main/java/frc/utils/pid/PIDConfig.java
@@ -1,21 +1,23 @@
 package frc.utils.pid;
 
+import edu.wpi.first.math.Pair;
 import java.util.HashMap;
 import java.util.function.BiConsumer;
 
-import edu.wpi.first.math.Pair;
-
 /**
- * Stores config values for a {@link com.revrobotics.SparkPIDController}. Contains some helper methods for abstraction.
+ * Stores config values for a {@link com.revrobotics.SparkPIDController}. Contains some helper
+ * methods for abstraction.
+ *
  * @see frc.utils.pid.PIDParam
  */
 public class PIDConfig {
-  
+
   // Stores mapping of PIDParam to the parameter key and value.
   private HashMap<PIDParam, Pair<String, Double>> configValues;
 
   /**
    * Constructs a new PIDConfig.
+   *
    * @param PGainKey
    * @param PGainValue
    * @param IGainKey
@@ -32,51 +34,48 @@ public class PIDConfig {
    * @param MinOutputValue
    */
   public PIDConfig(
-    String PGainKey, double PGainValue,
-    String IGainKey, double IGainValue,
-    String DGainKey, double DGainValue,
-    String IZoneKey, double IZoneValue,
-    String FFGainKey, double FFGainValue,
-    String MaxOutputKey, double MaxOutputValue,
-    String MinOutputKey, double MinOutputValue
-  ) {
-    this.configValues.put(PIDParam.P,         Pair.of(PGainKey, PGainValue));
-    this.configValues.put(PIDParam.I,         Pair.of(IGainKey, IGainValue));
-    this.configValues.put(PIDParam.D,         Pair.of(DGainKey, DGainValue));
-    this.configValues.put(PIDParam.IZone,     Pair.of(IZoneKey, IZoneValue));
-    this.configValues.put(PIDParam.FF,        Pair.of(FFGainKey, FFGainValue));
+      String PGainKey,
+      double PGainValue,
+      String IGainKey,
+      double IGainValue,
+      String DGainKey,
+      double DGainValue,
+      String IZoneKey,
+      double IZoneValue,
+      String FFGainKey,
+      double FFGainValue,
+      String MaxOutputKey,
+      double MaxOutputValue,
+      String MinOutputKey,
+      double MinOutputValue) {
+    this.configValues.put(PIDParam.P, Pair.of(PGainKey, PGainValue));
+    this.configValues.put(PIDParam.I, Pair.of(IGainKey, IGainValue));
+    this.configValues.put(PIDParam.D, Pair.of(DGainKey, DGainValue));
+    this.configValues.put(PIDParam.IZone, Pair.of(IZoneKey, IZoneValue));
+    this.configValues.put(PIDParam.FF, Pair.of(FFGainKey, FFGainValue));
     this.configValues.put(PIDParam.MaxOutput, Pair.of(MaxOutputKey, MaxOutputValue));
     this.configValues.put(PIDParam.MinOutput, Pair.of(MinOutputKey, MinOutputValue));
   }
 
-  /**
-   * Gets the key and value for the corresponding {@link frc.utils.pid.PIDParam}.
-   */
+  /** Gets the key and value for the corresponding {@link frc.utils.pid.PIDParam}. */
   public Pair<String, Double> get(PIDParam param) {
     return this.configValues.get(param);
   }
 
-  /**
-   * Gets the key for the corresponding {@link frc.utils.pid.PIDParam}.
-   */
+  /** Gets the key for the corresponding {@link frc.utils.pid.PIDParam}. */
   public String getKey(PIDParam param) {
     return this.configValues.get(param).getFirst();
   }
 
-  /**
-   * Gets the value for the corresponding {@link frc.utils.pid.PIDParam}.
-   */
+  /** Gets the value for the corresponding {@link frc.utils.pid.PIDParam}. */
   public double getValue(PIDParam param) {
     return this.configValues.get(param).getSecond();
   }
 
-  /**
-   * Iterates through the key and value for every {@link frc.utils.pid.PIDParam}.
-   */
+  /** Iterates through the key and value for every {@link frc.utils.pid.PIDParam}. */
   public void forEachPIDParam(BiConsumer<PIDParam, Pair<String, Double>> consumer) {
     for (PIDParam param : PIDParam.values()) {
       consumer.accept(param, this.get(param));
     }
   }
-
 }

--- a/src/main/java/frc/utils/pid/PIDConfig.java
+++ b/src/main/java/frc/utils/pid/PIDConfig.java
@@ -51,10 +51,10 @@ public class PIDConfig {
     this.configValues.put(PIDParam.P, Pair.of(PGainKey, PGainValue));
     this.configValues.put(PIDParam.I, Pair.of(IGainKey, IGainValue));
     this.configValues.put(PIDParam.D, Pair.of(DGainKey, DGainValue));
-    this.configValues.put(PIDParam.IZone, Pair.of(IZoneKey, IZoneValue));
+    this.configValues.put(PIDParam.I_ZONE, Pair.of(IZoneKey, IZoneValue));
     this.configValues.put(PIDParam.FF, Pair.of(FFGainKey, FFGainValue));
-    this.configValues.put(PIDParam.MaxOutput, Pair.of(MaxOutputKey, MaxOutputValue));
-    this.configValues.put(PIDParam.MinOutput, Pair.of(MinOutputKey, MinOutputValue));
+    this.configValues.put(PIDParam.MAX_OUTPUT, Pair.of(MaxOutputKey, MaxOutputValue));
+    this.configValues.put(PIDParam.MIN_OUTPUT, Pair.of(MinOutputKey, MinOutputValue));
   }
 
   /** Gets the key and value for the corresponding {@link frc.utils.pid.PIDParam}. */

--- a/src/main/java/frc/utils/pid/PIDConfig.java
+++ b/src/main/java/frc/utils/pid/PIDConfig.java
@@ -1,0 +1,82 @@
+package frc.utils.pid;
+
+import java.util.HashMap;
+import java.util.function.BiConsumer;
+
+import edu.wpi.first.math.Pair;
+
+/**
+ * Stores config values for a {@link com.revrobotics.SparkPIDController}. Contains some helper methods for abstraction.
+ * @see frc.utils.pid.PIDParam
+ */
+public class PIDConfig {
+  
+  // Stores mapping of PIDParam to the parameter key and value.
+  private HashMap<PIDParam, Pair<String, Double>> configValues;
+
+  /**
+   * Constructs a new PIDConfig.
+   * @param PGainKey
+   * @param PGainValue
+   * @param IGainKey
+   * @param IGainValue
+   * @param DGainKey
+   * @param DGainValue
+   * @param IZoneKey
+   * @param IZoneValue
+   * @param FFGainKey
+   * @param FFGainValue
+   * @param MaxOutputKey
+   * @param MaxOutputValue
+   * @param MinOutputKey
+   * @param MinOutputValue
+   */
+  public PIDConfig(
+    String PGainKey, double PGainValue,
+    String IGainKey, double IGainValue,
+    String DGainKey, double DGainValue,
+    String IZoneKey, double IZoneValue,
+    String FFGainKey, double FFGainValue,
+    String MaxOutputKey, double MaxOutputValue,
+    String MinOutputKey, double MinOutputValue
+  ) {
+    this.configValues.put(PIDParam.P,         Pair.of(PGainKey, PGainValue));
+    this.configValues.put(PIDParam.I,         Pair.of(IGainKey, IGainValue));
+    this.configValues.put(PIDParam.D,         Pair.of(DGainKey, DGainValue));
+    this.configValues.put(PIDParam.IZone,     Pair.of(IZoneKey, IZoneValue));
+    this.configValues.put(PIDParam.FF,        Pair.of(FFGainKey, FFGainValue));
+    this.configValues.put(PIDParam.MaxOutput, Pair.of(MaxOutputKey, MaxOutputValue));
+    this.configValues.put(PIDParam.MinOutput, Pair.of(MinOutputKey, MinOutputValue));
+  }
+
+  /**
+   * Gets the key and value for the corresponding {@link frc.utils.pid.PIDParam}.
+   */
+  public Pair<String, Double> get(PIDParam param) {
+    return this.configValues.get(param);
+  }
+
+  /**
+   * Gets the key for the corresponding {@link frc.utils.pid.PIDParam}.
+   */
+  public String getKey(PIDParam param) {
+    return this.configValues.get(param).getFirst();
+  }
+
+  /**
+   * Gets the value for the corresponding {@link frc.utils.pid.PIDParam}.
+   */
+  public double getValue(PIDParam param) {
+    return this.configValues.get(param).getSecond();
+  }
+
+  /**
+   * Iterates through the key and value for every {@link frc.utils.pid.PIDParam}.
+   */
+  public void forEachPIDParam(BiConsumer<PIDParam, Pair<String, Double>> consumer) {
+    for (PIDParam param : PIDParam.values()) {
+      consumer.accept(param, this.get(param));
+    }
+  }
+
+}

--- a/src/main/java/frc/utils/pid/PIDParam.java
+++ b/src/main/java/frc/utils/pid/PIDParam.java
@@ -5,8 +5,8 @@ public enum PIDParam {
   P,
   I,
   D,
-  IZone,
+  I_ZONE,
   FF,
-  MaxOutput,
-  MinOutput
+  MAX_OUTPUT,
+  MIN_OUTPUT
 }

--- a/src/main/java/frc/utils/pid/PIDParam.java
+++ b/src/main/java/frc/utils/pid/PIDParam.java
@@ -1,0 +1,14 @@
+package frc.utils.pid;
+
+/**
+ * Contains a value for each parameter of a {@link com.revrobotics.SparkPIDController}.
+ */
+public enum PIDParam {
+  P,
+  I,
+  D,
+  IZone,
+  FF,
+  MaxOutput,
+  MinOutput
+}

--- a/src/main/java/frc/utils/pid/PIDParam.java
+++ b/src/main/java/frc/utils/pid/PIDParam.java
@@ -1,8 +1,6 @@
 package frc.utils.pid;
 
-/**
- * Contains a value for each parameter of a {@link com.revrobotics.SparkPIDController}.
- */
+/** Contains a value for each parameter of a {@link com.revrobotics.SparkPIDController}. */
 public enum PIDParam {
   P,
   I,

--- a/src/main/java/frc/utils/pid/PIDUtils.java
+++ b/src/main/java/frc/utils/pid/PIDUtils.java
@@ -1,27 +1,32 @@
 package frc.utils.pid;
 
+import com.revrobotics.SparkPIDController;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-import com.revrobotics.SparkPIDController;
-
 /**
  * Contains helper methods for simplifying and abstracting code related to PID controllers.
+ *
  * @see frc.utils.pid.PIDConfig
  * @see frc.utils.pid.PIDParam
  */
 public final class PIDUtils {
 
-  private PIDUtils() { }
+  private PIDUtils() {}
 
   /**
-   * Maps a {@link frc.utils.pid.PIDParam} to the corresponding setter method of a {@link com.revrobotics.SparkPIDController}.
-   * <p> Example: {@code getCorrespondingSetMethod(controller, PIDParam.P)} will return a  {@link java.util.function.Consumer} {@code (value) -> controller.setP(value)}
+   * Maps a {@link frc.utils.pid.PIDParam} to the corresponding setter method of a {@link
+   * com.revrobotics.SparkPIDController}.
+   *
+   * <p>Example: {@code getCorrespondingSetMethod(controller, PIDParam.P)} will return a {@link
+   * java.util.function.Consumer} {@code (value) -> controller.setP(value)}
+   *
    * @param controller The PID controller that the mapping will target
    * @param pidParam The {@link frc.utils.pid.PIDParam} that the mapping will reference
    */
-  public static Consumer<Double> getCorrespondingSetMethod(SparkPIDController controller, PIDParam pidParam) {
-    
+  public static Consumer<Double> getCorrespondingSetMethod(
+      SparkPIDController controller, PIDParam pidParam) {
+
     Consumer<Double> returnValue = null;
 
     switch (pidParam) {
@@ -49,17 +54,21 @@ public final class PIDUtils {
     }
 
     return returnValue;
-
   }
 
   /**
-   * Maps a {@link frc.utils.pid.PIDParam} to the corresponding getter method of a {@link com.revrobotics.SparkPIDController}.
-   * <p> Example: {@code getCorrespondingGetMethod(controller, PIDParam.P)} will return a  {@link java.util.function.Supplier} {@code () -> controller.getP()}
+   * Maps a {@link frc.utils.pid.PIDParam} to the corresponding getter method of a {@link
+   * com.revrobotics.SparkPIDController}.
+   *
+   * <p>Example: {@code getCorrespondingGetMethod(controller, PIDParam.P)} will return a {@link
+   * java.util.function.Supplier} {@code () -> controller.getP()}
+   *
    * @param controller The PID controller that the mapping will target
    * @param pidParam The {@link frc.utils.pid.PIDParam} that the mapping will reference
    */
-  public static Supplier<Double> getCorrespondingGetMethod(SparkPIDController controller, PIDParam pidParam) {
-    
+  public static Supplier<Double> getCorrespondingGetMethod(
+      SparkPIDController controller, PIDParam pidParam) {
+
     Supplier<Double> returnValue = null;
 
     switch (pidParam) {
@@ -87,7 +96,5 @@ public final class PIDUtils {
     }
 
     return returnValue;
-
   }
-  
 }

--- a/src/main/java/frc/utils/pid/PIDUtils.java
+++ b/src/main/java/frc/utils/pid/PIDUtils.java
@@ -39,16 +39,16 @@ public final class PIDUtils {
       case D:
         returnValue = x -> controller.setD(x);
         break;
-      case IZone:
+      case I_ZONE:
         returnValue = x -> controller.setIZone(x);
         break;
       case FF:
         returnValue = x -> controller.setFF(x);
         break;
-      case MaxOutput:
+      case MAX_OUTPUT:
         returnValue = x -> controller.setOutputRange(controller.getOutputMin(), x);
         break;
-      case MinOutput:
+      case MIN_OUTPUT:
         returnValue = x -> controller.setOutputRange(x, controller.getOutputMax());
         break;
     }
@@ -81,16 +81,16 @@ public final class PIDUtils {
       case D:
         returnValue = () -> controller.getD();
         break;
-      case IZone:
+      case I_ZONE:
         returnValue = () -> controller.getIZone();
         break;
       case FF:
         returnValue = () -> controller.getFF();
         break;
-      case MaxOutput:
+      case MAX_OUTPUT:
         returnValue = () -> controller.getOutputMax();
         break;
-      case MinOutput:
+      case MIN_OUTPUT:
         returnValue = () -> controller.getOutputMin();
         break;
     }

--- a/src/main/java/frc/utils/pid/PIDUtils.java
+++ b/src/main/java/frc/utils/pid/PIDUtils.java
@@ -1,0 +1,93 @@
+package frc.utils.pid;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import com.revrobotics.SparkPIDController;
+
+/**
+ * Contains helper methods for simplifying and abstracting code related to PID controllers.
+ * @see frc.utils.pid.PIDConfig
+ * @see frc.utils.pid.PIDParam
+ */
+public final class PIDUtils {
+
+  private PIDUtils() { }
+
+  /**
+   * Maps a {@link frc.utils.pid.PIDParam} to the corresponding setter method of a {@link com.revrobotics.SparkPIDController}.
+   * <p> Example: {@code getCorrespondingSetMethod(controller, PIDParam.P)} will return a  {@link java.util.function.Consumer} {@code (value) -> controller.setP(value)}
+   * @param controller The PID controller that the mapping will target
+   * @param pidParam The {@link frc.utils.pid.PIDParam} that the mapping will reference
+   */
+  public static Consumer<Double> getCorrespondingSetMethod(SparkPIDController controller, PIDParam pidParam) {
+    
+    Consumer<Double> returnValue = null;
+
+    switch (pidParam) {
+      case P:
+        returnValue = x -> controller.setP(x);
+        break;
+      case I:
+        returnValue = x -> controller.setI(x);
+        break;
+      case D:
+        returnValue = x -> controller.setD(x);
+        break;
+      case IZone:
+        returnValue = x -> controller.setIZone(x);
+        break;
+      case FF:
+        returnValue = x -> controller.setFF(x);
+        break;
+      case MaxOutput:
+        returnValue = x -> controller.setOutputRange(controller.getOutputMin(), x);
+        break;
+      case MinOutput:
+        returnValue = x -> controller.setOutputRange(x, controller.getOutputMax());
+        break;
+    }
+
+    return returnValue;
+
+  }
+
+  /**
+   * Maps a {@link frc.utils.pid.PIDParam} to the corresponding getter method of a {@link com.revrobotics.SparkPIDController}.
+   * <p> Example: {@code getCorrespondingGetMethod(controller, PIDParam.P)} will return a  {@link java.util.function.Supplier} {@code () -> controller.getP()}
+   * @param controller The PID controller that the mapping will target
+   * @param pidParam The {@link frc.utils.pid.PIDParam} that the mapping will reference
+   */
+  public static Supplier<Double> getCorrespondingGetMethod(SparkPIDController controller, PIDParam pidParam) {
+    
+    Supplier<Double> returnValue = null;
+
+    switch (pidParam) {
+      case P:
+        returnValue = () -> controller.getP();
+        break;
+      case I:
+        returnValue = () -> controller.getI();
+        break;
+      case D:
+        returnValue = () -> controller.getD();
+        break;
+      case IZone:
+        returnValue = () -> controller.getIZone();
+        break;
+      case FF:
+        returnValue = () -> controller.getFF();
+        break;
+      case MaxOutput:
+        returnValue = () -> controller.getOutputMax();
+        break;
+      case MinOutput:
+        returnValue = () -> controller.getOutputMin();
+        break;
+    }
+
+    return returnValue;
+
+  }
+  
+}


### PR DESCRIPTION
An abstraction of several PID controller related functionalities, the primary goal of which is to reduce the highly repetitive and tedious boilerplate associated with working with PID controllers and parameters.

This is done mainly by moving individual parameters into an iterable data structure. Preferably, the configuration would be data-driven as well but I'll leave that be for now....

Examples of the usage and extensibility of these classes can be found in https://gist.github.com/Alexander3847575/c5ad192a3d2df8a6288e3d86e7ccaa47

(diff recommended, raw line count reduction is ~130 ignoring config initialization; see comment in relevant code)

Please review and let me know what changes I should make! 